### PR TITLE
chore: add shell-emulator=true in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shell-emulator=true


### PR DESCRIPTION
[ shell-emulator docs ](https://pnpm.io/cli/run#shell-emulator) 

Before adding `shell-emulator=true` in .npmrc, it can't run `pnpm build` on Windows and logs are following :

```bash
temir on  main via 🌰 v16.16.0 
❯ pnpm build

> temir@0.0.5 build G:\codes\temir       
> pnpm --filter './packages/**' run build

No projects matched the filters in "G:\codes\temir"
```