### PR TITLE
fix(core): initialize `fullStaticOutput`

### DIFF
--- a/packages/temir/src/temir.ts
+++ b/packages/temir/src/temir.ts
@@ -34,7 +34,7 @@ export default class Temir {
   // Ignore last render after unmounting a tree to prevent empty output before exit
   private isUnmounted: boolean
   private rootNode: dom.DOMElement
-  private fullStaticOutput: string
+  private fullStaticOutput = ''
   private lastOutput: string
   private exitPromise?: Promise<void>
   private restoreConsole?: () => void

--- a/packages/temir/src/temir.ts
+++ b/packages/temir/src/temir.ts
@@ -95,7 +95,7 @@ export default class Temir {
       if (hasStaticOutput)
         this.fullStaticOutput += staticOutput
 
-      this.options.stdout.write(this.fullStaticOutput ?? `${output}`)
+      this.options.stdout.write(this.fullStaticOutput || `${output}`)
       return
     }
 


### PR DESCRIPTION
## reproduction
in my case, an `undefined` was at the beginning when it reaches this branch: https://github.com/webfansplz/temir/blob/686deb80ddc857d9f367d5a92d530525a5c81070/packages/temir/src/temir.ts#L113
![image](https://user-images.githubusercontent.com/30516060/186433561-f3b2e927-4e01-4ca9-9ac0-5dd7bab6cf3e.png)


## cause
`+` operation gets an `'undefined'` string.
https://github.com/webfansplz/temir/blob/686deb80ddc857d9f367d5a92d530525a5c81070/packages/temir/src/temir.ts#L115